### PR TITLE
including optional "message" field for "fail" status

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ When setting up a JSON API, you'll have all kinds of different types of calls an
 <table>
 <tr><th>Type</td><th>Description</th><th>Required Keys</th><th>Optional Keys</td></tr>
 <tr><td>success</td><td>All went well, and (usually) some data was returned.</td><td>status, data</td><td></td></tr>
-<tr><td>fail</td><td>There was a problem with the data submitted, or some pre-condition of the API call wasn't satisfied</td><td>status, data</td><td></td></tr>
+<tr><td>fail</td><td>There was a problem with the data submitted, or some pre-condition of the API call wasn't satisfied</td><td>status, data</td><td>message</td></tr>
 <tr><td>error</td><td>An error occurred in processing the request, i.e. an exception was thrown</td><td>status, message</td><td>code, data</td></tr>
 </table>
 


### PR DESCRIPTION
We usually send "fail" status if validation errors exist with request data.
Sometimes, the failed message may not be included with any key of request payload(for example: when the input data is included in request parameters, instead of request body).
In such situations, adding an optional "message" field with response( just like in error condition) would make this standard even more flexible.